### PR TITLE
Rename common target

### DIFF
--- a/src/common/src/CMakeLists.txt
+++ b/src/common/src/CMakeLists.txt
@@ -1,13 +1,13 @@
-add_library(common STATIC
-                   data_buffer_interface.cpp
-                   octet_string.cpp)
+add_library(gse_common STATIC
+                       data_buffer_interface.cpp
+                       octet_string.cpp)
 
 if (WIN32)
-    target_link_libraries(common PRIVATE ws2_32)
+    target_link_libraries(gse_common PRIVATE ws2_32)
 endif()
 
-target_compile_options(common PRIVATE
+target_compile_options(gse_common PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wpedantic -Wextra -Werror -Wall>
      $<$<CXX_COMPILER_ID:MSVC>: /WX>)
 
-target_include_directories(common PUBLIC ${CMAKE_SOURCE_DIR}/src/common/include)
+target_include_directories(gse_common PUBLIC ${CMAKE_SOURCE_DIR}/src/common/include)

--- a/src/gse/src/CMakeLists.txt
+++ b/src/gse/src/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(gse gs_api.cpp
                 gs_serializer.cpp
                 half_float.cpp)
 
-set_target_properties(common PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
-target_link_libraries(gse PRIVATE common)
+set_target_properties(gse_common PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
+target_link_libraries(gse PRIVATE gse_common)
 
 target_compile_options(gse PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wpedantic -Wextra -Werror -Wall>

--- a/test/test_gs_api/CMakeLists.txt
+++ b/test/test_gs_api/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(test_gs_api test_main.cpp test_gs_api.cpp)
 
 include(GoogleTest)
 
-target_link_libraries(test_gs_api PRIVATE gse common GTest::GTest GTest::Main)
+target_link_libraries(test_gs_api PRIVATE gse gse_common GTest::GTest GTest::Main)
 
 add_test(NAME test_gs_api
          COMMAND test_gs_api)

--- a/test/test_gs_decoder/CMakeLists.txt
+++ b/test/test_gs_decoder/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(test_gs_decoder test_main.cpp test_gs_decoder.cpp)
 
 include(GoogleTest)
 
-target_link_libraries(test_gs_decoder PRIVATE gse common GTest::GTest GTest::Main)
+target_link_libraries(test_gs_decoder PRIVATE gse gse_common GTest::GTest GTest::Main)
 
 add_test(NAME test_gs_decoder
          COMMAND test_gs_decoder)

--- a/test/test_gs_deserializer/CMakeLists.txt
+++ b/test/test_gs_deserializer/CMakeLists.txt
@@ -4,7 +4,7 @@ target_include_directories(test_gs_deserializer PRIVATE ${CMAKE_SOURCE_DIR}/src/
 
 include(GoogleTest)
 
-target_link_libraries(test_gs_deserializer PRIVATE gse common GTest::GTest GTest::Main)
+target_link_libraries(test_gs_deserializer PRIVATE gse gse_common GTest::GTest GTest::Main)
 
 add_test(NAME test_gs_deserializer
          COMMAND test_gs_deserializer)

--- a/test/test_gs_encoder/CMakeLists.txt
+++ b/test/test_gs_encoder/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(test_gs_encoder test_main.cpp test_gs_encoder.cpp)
 
 include(GoogleTest)
 
-target_link_libraries(test_gs_encoder PRIVATE gse common GTest::GTest GTest::Main)
+target_link_libraries(test_gs_encoder PRIVATE gse gse_common GTest::GTest GTest::Main)
 
 add_test(NAME test_gs_encoder
          COMMAND test_gs_encoder)

--- a/test/test_gs_serializer/CMakeLists.txt
+++ b/test/test_gs_serializer/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(test_gs_serializer test_main.cpp test_gs_serializer.cpp)
 
 include(GoogleTest)
 
-target_link_libraries(test_gs_serializer PRIVATE gse common GTest::GTest GTest::Main)
+target_link_libraries(test_gs_serializer PRIVATE gse gse_common GTest::GTest GTest::Main)
 
 add_test(NAME test_gs_serializer
          COMMAND test_gs_serializer)


### PR DESCRIPTION
`common` is a potentially ...common... target name that might cause issues if including this project using something like CMake's `FetchContent` as in our use case. There may be a more elegant solution, but renaming the target to something more specific (`gse_common`) is a simple fix. 