### PR TITLE
Add CMake build action

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,37 @@
+name: CMake
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}
+      

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,11 +19,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    
+    - name: Checkout vcpkg
+      uses: actions/checkout@v3
+      with:
+        repository: microsoft/vcpkg
+        path: vcpkg
+    
+    - name: Bootstrap vcpkg
+      run: ./${{github.workspace}}/vcpkg/bootstrap-vcpkg.sh
+    
+    - name: Install GTest
+      run: ./${{github.workspace}}/vcpkg/vcpkg install gtest
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -27,10 +27,10 @@ jobs:
         path: vcpkg
     
     - name: Bootstrap vcpkg
-      run: ./${{github.workspace}}/vcpkg/bootstrap-vcpkg.sh
+      run: sh ${{github.workspace}}/vcpkg/bootstrap-vcpkg.sh
     
     - name: Install GTest
-      run: ./${{github.workspace}}/vcpkg/vcpkg install gtest
+      run: ${{github.workspace}}/vcpkg/vcpkg install gtest
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.


### PR DESCRIPTION
Add GitHub action for CMake build and test. I grabbed vcpkg for the gtest dependency which might be overkill but if we ever added a manifest to the project it would make more sense than another option. 