### PR TITLE
Changed to the encoder/decoder context variables

### DIFF
--- a/include/gs_api.h
+++ b/include/gs_api.h
@@ -255,15 +255,9 @@ typedef struct
     } u;
 } GS_Object;
 
-typedef struct
-{
-    void *opaque;
-} GS_Encoder_Context;
-
-typedef struct
-{
-    void *opaque;
-} GS_Decoder_Context;
+// Encoder and decoder context types
+typedef struct GS_Encoder_Context GS_Encoder_Context;
+typedef struct GS_Decoder_Context GS_Decoder_Context;
 
 // Function prototypes for the public API
 EXPORT int CALL GSEncoderInit(GS_Encoder_Context **gs_encoder_context,

--- a/src/gs_api_internal.h
+++ b/src/gs_api_internal.h
@@ -68,7 +68,7 @@ typedef struct
 typedef struct
 {
     gs::Decoder decoder;                        // gs::Decoder object
-    gs::DataBuffer data_buffer;               // DataBuffer object
+    gs::DataBuffer data_buffer;                 // DataBuffer object
     std::string error;                          // Text for last error
     std::vector<std::uint8_t *> allocations;    // Memory allocations
 } GS_Decoder_Context_Internal;


### PR DESCRIPTION
Better "hide" the context variable information by putting the definition in the .cpp module and just making a forward reference.  Also, this allowed removal of an additional pointer and, thus, one fewer calls to `new` and `delete`.