### PR TITLE
Change platform define

### DIFF
--- a/include/gs_api.h
+++ b/include/gs_api.h
@@ -48,7 +48,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__unix__) || defined(__APPLE__)
 #define EXPORT
 #define CALL
 #elif _WIN32


### PR DESCRIPTION
Altering the platform define to `__unix__` from `__linux__`. Specifically this means not having to add an additional case when crosscompiling to WebAssembly, and I don't believe we would expect any issues on linux vs unix in our codebase.